### PR TITLE
Update joss.yml

### DIFF
--- a/.github/workflows/joss.yml
+++ b/.github/workflows/joss.yml
@@ -20,7 +20,7 @@ jobs:
           # This should be the path to the paper within your repo.
           paper-path: joss/paper.md
       - name: Upload
-        uses: actions/upload-artifact@v1
+        uses: actions/upload-artifact@v4
         with:
           name: paper
           # This is the output path where Pandoc will write the compiled


### PR DESCRIPTION
Changed "actions/upload-artifact@v1" to "actions/upload-artifact@v4" as v1 and v2 are deprecated