### PR TITLE
Hints to succeed compilation on a M1 architectures

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -42,7 +42,7 @@ if 'darwin' in OS:
     library_dirs.append('/opt/local/lib')
     extra_compile_args.append('-Wno-#warnings')
     extra_compile_args.append('-Wno-error=format-security')
-    include_dirs.extend(['/usr/local/include', '/usr/local/opt/llvm/include', './neost'])
+    include_dirs.extend(['/usr/local/include', '/usr/local/opt/llvm/include', './neost/tovsolvers/'])
 
 else:
     # point to shared library at compile time so runtime resolution

--- a/setup.py
+++ b/setup.py
@@ -30,19 +30,19 @@ else:
 
 # Common includes, linker arguments, compiler arguments
 include_dirs = [np.get_include(), gsl_prefix+'/include', '.']
-extra_link_args = ['-fopenmp']
-extra_compile_args = ['-fopenmp', '-Wno-unused-function', '-Wno-uninitialized']
+extra_link_args = []
+extra_compile_args = ['-Wno-unused-function', '-Wno-uninitialized']
 
 # OS-specific settings
 if 'darwin' in OS:
     # Using compiler of clang with llvm installed
-    os.environ["CC"] = "/usr/local/opt/llvm/bin/clang"
-    os.environ["CXX"] = "/usr/local/opt/llvm/bin/clang++"
+    # os.environ["CC"] = "/usr/local/opt/llvm/bin/clang"
+    # os.environ["CXX"] = "/usr/local/opt/llvm/bin/clang++"
     library_dirs.append('/usr/local/opt/llvm/lib')
     library_dirs.append('/opt/local/lib')
     extra_compile_args.append('-Wno-#warnings')
     extra_compile_args.append('-Wno-error=format-security')
-    include_dirs.append(['/usr/local/include', '/usr/local/opt/llvm/include', './neost'])
+    include_dirs.extend(['/usr/local/include', '/usr/local/opt/llvm/include', './neost'])
 
 else:
     # point to shared library at compile time so runtime resolution


### PR DESCRIPTION
I spent a minimal amount of time to debug the installation issues reported in #48. This PR contains the changes for a successful local build. I think it can serve as a basis to improve the installation for Mac. Here are some hints:

- The  `TypeError: unhashable type: 'list'` was triggered by the fact that in line 45 the `included_dirs` where appended instead of extended.
- Then it failed with not finding `GSL.pxd`, which could be fixed by providing the correct include dir of `'./neost/tovsolvers/'`
- I proceeded to just use my standard clang and not bother with open mp support. Hence I just commented out those section. However I would recommend to be less restrictive ("hard coding") compiler locations. Please try to find what the recommended standards are for this and update the `setup.py` accordingly.