### PR TITLE
Documentation updates to include the Cython versus Python speed-up

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -35,7 +35,7 @@ Installation and Testing
 
 NEoST is best installed from source. The documentation provides
 `step-by-step installation instructions <https://xpsi-group.github.io/neost/install.html>`_
-for Linux and for limited MacOS systems.
+for Linux and for limited MacOS systems. Note, NEoST offers two install options for the Tolman-Oppenheimer-Volkoff equation solvers: one using Cython and the other using Python. If one wishes to install using Python (e.g., due to incompatability with Cython and so the TOV solvers don't cythonize), we estimate the approximate speed-up of using Cython to Python to be at least 15x (if dark matter is turned on) and 20x (if dark matter is turned off).
 
 Documentation
 -------------

--- a/docs/source/install.rst
+++ b/docs/source/install.rst
@@ -129,7 +129,7 @@ or, equivalently,
 
 	pip install .
 
-NEoST can optionally be installed without cythonizing the TOV solvers, at the expense of much slower performance. If you wish to do this, rename or delete the ``setup.py`` file before running ``make install``.  We only recommend using the Python TOV solvers if the cythonized solvers fail to compile or run.  Note that the unit tests in the ``tests/`` directory fail if the Python solvers are used; this is expected.
+NEoST can optionally be installed without cythonizing the TOV solvers, at the expense of much slower performance. More specificaly, Cython offers a speed up of at least 15x (if dark matter is turned on) and 20x (if dark matter is turned off). If you wish to do this, rename or delete the ``setup.py`` file before running ``make install``.  We only recommend using the Python TOV solvers if the cythonized solvers fail to compile or run.  Note that the unit tests in the ``tests/`` directory fail if the Python solvers are used; this is expected.
 
 
 


### PR DESCRIPTION
I did this comparing Cython and Python using the %timeit magic function when sampling 100 EoSs and computing their corresponding log-likelihoods 10 times over. Here I found that for the TOVdm vs TOVdm_python the speed-up is about 15x and for TOVr vs TOVr_python the speed-up is about 20x. This difference is because the TOVdm/TOVdm_python solvers have to compute the adm_fraction is slows both codes down. 