### PR TITLE
Updates to Zenodo integration pipeline

### DIFF
--- a/.github/workflows/build_docs.yml
+++ b/.github/workflows/build_docs.yml
@@ -4,7 +4,6 @@ on:
   push:
     branches:
       - main
-  release:
   workflow_dispatch:
 
 jobs:
@@ -18,9 +17,9 @@ jobs:
       max-parallel: 5
 
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v6
     - name: Install Conda environment with Micromamba
-      uses: mamba-org/setup-micromamba@v1
+      uses: mamba-org/setup-micromamba@v2
       with:
         environment-file: environment.yml
         cache-env: true
@@ -48,7 +47,7 @@ jobs:
 
     - name: Deploy to GitHub Pages
       if: success()
-      uses: crazy-max/ghaction-github-pages@v3
+      uses: crazy-max/ghaction-github-pages@v5
       with:
         target_branch: gh-pages
         build_dir: docs/build/html

--- a/.zenodo.json
+++ b/.zenodo.json
@@ -1,0 +1,56 @@
+{
+    "creators": [
+        {
+            "name": "Raaijmakers, Geert",
+            "orcid": "0000-0002-9397-786X"
+        },
+        {
+            "name": "Rutherford, Nathan",
+            "affiliation": "Foundational Questions Institute (FQxI)",
+            "orcid": "0000-0002-9626-7257"
+        },
+        {
+            "name": "Timmerman, Patrick",
+            "orcid": "0009-0003-2793-1569"
+        },        
+        {
+            "name": "Salmi, Tuomo",
+            "affiliation": "University of Helsinki",
+            "orcid": "0000-0001-6356-125X"
+        },   
+        {
+            "name": "Watts, Anna",
+            "affiliation": "University of Amsterdam",
+            "orcid": "0000-0002-1009-2354"
+        },        
+        {
+            "name": "Prescod-Weinstein, Chanda",
+            "affiliation": "University of New Hampshire",
+            "orcid": "0000-0002-6742-4532"
+        },        
+        {
+            "name": "Svensson, Isak",
+            "affiliation": "Technical University of Darmstadt",
+            "orcid": "0000-0002-9211-5555"
+        },
+        {
+            "name": "Mendes, Melissa",
+            "affiliation": "Technical University of Darmstadt",
+            "orcid": "0009-0007-0697-8869"
+        }
+    ],
+    "title": "xpsi-group/neost: Release v2.3.0",
+    "version": "2.3.0",
+    "license": "gpl-3.0-or-later",
+    "upload_type": "software",
+    "language": "eng",
+    "grants": [
+       {"id": "00k4n6c32::865768"},
+       {"id": "00k4n6c32::639217"},
+       {"id": "00k4n6c32::101020842"},
+       {"id": "04jsz6e67::639.042.612"},
+       {"id": "04jsz6e67::680-91-134"},
+       {"id": "04jsz6e67::OCENW.XL21.XL21.038"},
+       {"id": "10.13039/100000104::80NSSC22K0092"}
+    ]
+}


### PR DESCRIPTION
Two small updates to fix issues with the Zenodo integration. We've just made similar changes to the X-PSI repository. 

In build_docs.yml, removed the release trigger that was causing looping/crashes, and updated action versions. Closes #80 .

Added .zenodo.json file to deal with formatting authors/funding information when new releases are tagged and ported to Zenodo. You'll need to make sure that the tag matches your intended new release number though.   I'm not 100% sure that the funder/grant ID information for Samaya's Vidi/Projectruimte grants is correct but I can correct those on Zenodo if it doesn't work properly and update it for next time.  Closes #84 